### PR TITLE
changed current to target state

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,12 +51,9 @@ CmdLockAccessory.prototype = {
 
 				if (!lock && this.auto_lock) {
 					setTimeout(function(instance) {
-						instance.cmdRequest(instance.lock_cmd, function(error, stdout, stderr) {
-							instance.log('Auto lock function succeeded!');
-							instance.lockService.setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED);
-							instance.log(stdout);
-						}.bind(this));
-					}, this.auto_lock_delay*1000, this);
+            instance.lockService.setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED);
+            instance.log('Auto lock function succeeded!');
+					}.bind(this), this.auto_lock_delay*1000, this);
 				}
 				callback();
 			}

--- a/index.js
+++ b/index.js
@@ -95,9 +95,9 @@ CmdLockAccessory.prototype = {
 			.on('get', this.getState.bind(this));
 
 		this.lockService
-			.getCharacteristic(Characteristic.LockTargetState)
-			.on('get', this.getState.bind(this))
-			.on('set', this.setState.bind(this));
+                        .setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED)
+                        .getCharacteristic(Characteristic.LockTargetState)
+                        .on('set', this.setState.bind(this));
 
 		return [this.lockService];
 	}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ CmdLockAccessory.prototype = {
 					setTimeout(function(instance) {
 						instance.cmdRequest(instance.lock_cmd, function(error, stdout, stderr) {
 							instance.log('Auto lock function succeeded!');
-							instance.lockService.setCharacteristic(Characteristic.LockCurrentState, Characteristic.LockCurrentState.SECURED);
+							instance.lockService.setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED);
 							instance.log(stdout);
 						}.bind(this));
 					}, this.auto_lock_delay*1000, this);

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ CmdLockAccessory.prototype = {
 
 				if (!lock && this.auto_lock) {
 					setTimeout(function(instance) {
-            instance.lockService.setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED);
-            instance.log('Auto lock function succeeded!');
+						instance.lockService.setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED);
+						instance.log('Auto lock function succeeded!');
 					}.bind(this), this.auto_lock_delay*1000, this);
 				}
 				callback();


### PR DESCRIPTION
After auto-locking successfully locked my door, the state kept "updating" in the homekit app:

![img_251b4a60e09a-1](https://user-images.githubusercontent.com/17352786/41808978-1f44d30e-76e6-11e8-9053-e813f319aec0.jpeg)

This change fixed it for me! Here's my breakdown:

When button is pressed to unlock, `setState` is called, `lock` is `false` and the TargetState characteristic is `Characteristic.LockTargetState.UNSECURED`. CurrentState characteristic is correctly set to `Characteristic.LockCurrentState.UNSECURED` after the `unlock_cmd` ran.

After the `auto_lock_delay` the `lock_cmd` is ran and the CurrentState characteristic is set to `Characteristic.LockCurrentState.SECURED`, the TargetState characteristic remains `Characteristic.LockTargetState.UNSECURED`. 

This therefore tells HomeKit the lock is busy unlocking.